### PR TITLE
Fix similar names conflicts

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,10 +30,15 @@ module.exports = postcss.plugin("postcss-color-function", function() {
  * @return {String}        converted declaration value to rgba()
  */
 function transformColor(string, source) {
-  var index = string.indexOf("color(")
-  if (index == -1) {
+  var index = string.search(/(^|[^\w\-])color\(/)
+
+  if (index === -1) {
     return string
   }
+
+  // NOTE: regexp search beginning of line of non char symbol before `color(`.
+  //       Offset used for second case.
+  index = index === 0 ? index : index + 1
 
   var fn = string.slice(index)
   var balancedMatches = balanced("(", ")", fn)

--- a/test/fixtures/color.css
+++ b/test/fixtures/color.css
@@ -3,4 +3,8 @@ body {
   background-color: color(red tint(50%));
   border-color: color(hsla(125, 50%, 50%, .4) hue(200));
   border-top-color: color(hwb(270, 10%, 0%) contrast(50%));
+
+  border-bottom-color: hover-color(red);
+
+  border-right-color: hover-color(color(red tint(50%)));
 }

--- a/test/fixtures/color.expected.css
+++ b/test/fixtures/color.expected.css
@@ -3,4 +3,8 @@ body {
   background-color: rgb(255, 128, 128);
   border-color: rgba(64, 149, 191, 0.4);
   border-top-color: rgb(248, 240, 255);
+
+  border-bottom-color: hover-color(red);
+
+  border-right-color: hover-color(rgb(255, 128, 128));
 }


### PR DESCRIPTION
Hi, @MoOx!

I find bug in `postcss-color-function` when use my own project-only plugin, which process `hover-color(<color>)` patterns. `postcss-color-function` find `color` in `hover-color` definition, and process them. For example: 

``` css
/* before */
.example { color: hover-color(red); }

/* after */
.example { color: hover-rgb(255, 0, 0); }
```

I fix checks in `postcss-color-function` and add additional test cases in fixtures.
