### PR TITLE
Update to css-color-function 1.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   ],
   "dependencies": {
     "balanced-match": "^0.1.0",
-    "css-color-function": "^1.2.0",
+    "css-color-function": "^1.3.0",
     "postcss": "^5.0.4",
     "postcss-message-helpers": "^2.0.0"
   },

--- a/test/fixtures/color.css
+++ b/test/fixtures/color.css
@@ -8,3 +8,8 @@ body {
 
   border-right-color: hover-color(color(red tint(50%)));
 }
+
+.hue {
+  border-color: color(hsla(0, 100%, 50%, .4) hue(- 120));
+  border-left-color: color(blue hue(+ 120));
+}

--- a/test/fixtures/color.expected.css
+++ b/test/fixtures/color.expected.css
@@ -8,3 +8,8 @@ body {
 
   border-right-color: hover-color(rgb(255, 128, 128));
 }
+
+.hue {
+  border-color: rgba(0, 0, 255, 0.4);
+  border-left-color: rgb(255, 0, 0);
+}


### PR DESCRIPTION
Newer version of `css-color-function` handles hue according to CSS Color W3C Editor’s Draft.

This PR adopts it and fixes issue #13.
