### PR TITLE
Retain whitespace before color().  Fix for #26.

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,10 +20,10 @@
     "index.js"
   ],
   "dependencies": {
-    "balanced-match": "^0.1.0",
     "css-color-function": "^1.2.0",
     "postcss": "^5.0.4",
-    "postcss-message-helpers": "^2.0.0"
+    "postcss-message-helpers": "^2.0.0",
+    "postcss-value-parser": "^3.3.0"
   },
   "devDependencies": {
     "jscs": "^1.6.2",

--- a/test/fixtures/color.css
+++ b/test/fixtures/color.css
@@ -7,4 +7,6 @@ body {
   border-bottom-color: hover-color(red);
 
   border-right-color: hover-color(color(red tint(50%)));
+
+  border-color: color(#999 a(0.8)) color(#999 a(0.8));
 }

--- a/test/fixtures/color.expected.css
+++ b/test/fixtures/color.expected.css
@@ -7,4 +7,6 @@ body {
   border-bottom-color: hover-color(red);
 
   border-right-color: hover-color(rgb(255, 128, 128));
+
+  border-color: rgba(153, 153, 153, 0.8) rgba(153, 153, 153, 0.8);
 }


### PR DESCRIPTION
Replace balance-matched with postcss-value-parser to fix issue whitespace removal issue #26.
