### PR TITLE
Tests and fix for upstream css-color-function bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "index.js"
   ],
   "dependencies": {
-    "css-color-function": "ianstormtaylor/css-color-function.git#1.3.1",
+    "css-color-function": "~1.3.3",
     "postcss": "^6.0.1",
     "postcss-message-helpers": "^2.0.0",
     "postcss-value-parser": "^3.3.0"

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "index.js"
   ],
   "dependencies": {
-    "css-color-function": "^1.3.0",
+    "css-color-function": "ianstormtaylor/css-color-function.git#1.3.1",
     "postcss": "^6.0.1",
     "postcss-message-helpers": "^2.0.0",
     "postcss-value-parser": "^3.3.0"

--- a/test/fixtures/color.css
+++ b/test/fixtures/color.css
@@ -12,7 +12,7 @@ body {
 }
 
 .withAlpha {
-  color: color(black a(90%) contrast(99%));
+  color: color(black a(80%) contrast(99%));
   background-color: color(red a(50%) shade(50%));
   border-color: color(red a(80%) tint(50%));
 }

--- a/test/fixtures/color.css
+++ b/test/fixtures/color.css
@@ -10,3 +10,9 @@ body {
 
   border-color: color(#999 a(0.8)) color(#999 a(0.8));
 }
+
+.withAlpha {
+  color: color(black a(90%) contrast(99%));
+  background-color: color(red a(50%) shade(50%));
+  border-color: color(red a(80%) tint(50%));
+}

--- a/test/fixtures/color.expected.css
+++ b/test/fixtures/color.expected.css
@@ -10,3 +10,9 @@ body {
 
   border-color: rgba(153, 153, 153, 0.8) rgba(153, 153, 153, 0.8);
 }
+
+.withAlpha {
+  color: rgba(255, 255, 255, 0.9);
+  background-color: rgba(128, 0, 0, 0.5);
+  border-color: rgba(255, 128, 128, 0.8);
+}

--- a/test/fixtures/color.expected.css
+++ b/test/fixtures/color.expected.css
@@ -12,7 +12,7 @@ body {
 }
 
 .withAlpha {
-  color: rgba(255, 255, 255, 0.9);
+  color: rgba(255, 255, 255, 0.8);
   background-color: rgba(128, 0, 0, 0.5);
   border-color: rgba(255, 128, 128, 0.8);
 }


### PR DESCRIPTION
**Ready for merge**

**Update 2017-10-09:**
`css-color-function@1.3.3` Includes the tint/shade/contrast bug fix. This PR points to that tag now.  Can ignore pretty much everything below.

~~This PR points to ~my fork~ the 1.3.1 tag of `css-color-function`, so I'm guessing you'd want to wait until the npm package is updated, but wanted to go ahead and get the work in.~~

Currently, there's a bug in `css-color-function` when using the `tint`, `shade`, and `contrast` adjusters along with the `alpha` adjuster. This is due to it's use of the `mix` function in the Color package it's using.

~~I have a PR in for the fix there and added more detailed around the problem and solution https://github.com/ianstormtaylor/css-color-function/pull/26~~

This PR adds tests for the issues and I pushed one failure up so you can see what happens: https://travis-ci.org/tylergaw/postcss-color-function/builds/190518140

For now, I'm just pointing to my fork of css color function to see the code working/tests passing: https://travis-ci.org/tylergaw/postcss-color-function/builds/190518745

~Once PR 26 gets merged I can update the dep here to use the og package.~

**Update 2017-07-15**
We merged PR/26 over in css-color-function ~~and created a 1.3.1 tag, but have not yet published it to NPM.~~

~~This PR now points to Ian's og repo, directly to `#1.3.1`~~