### PR TITLE
Ignore CSS custom properties in color(<color>)

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,15 +10,35 @@ var helpers = require("postcss-message-helpers")
  * PostCSS plugin to transform color()
  */
 module.exports = postcss.plugin("postcss-color-function", function() {
-  return function(style) {
-    style.walkDecls(function transformDecl(decl) {
+  return function(css, result) {
+    css.walkDecls(function transformDecl(decl) {
       if (!decl.value || decl.value.indexOf("color(") === -1) {
         return
       }
 
-      decl.value = helpers.try(function transformColorValue() {
-        return transformColor(decl.value)
-      }, decl.source)
+      if (decl.value.indexOf("var(") !== -1) {
+        result.messages.push({
+          plugin: "postcss-color-function",
+          type: "skipped-color-function-with-custom-property",
+          word: decl.value,
+          message:
+            "Skipped color function with custom property `" +
+            decl.value +
+            "`"
+        })
+        return
+      }
+
+      try {
+        decl.value = helpers.try(function transformColorValue() {
+          return transformColor(decl.value)
+        }, decl.source)
+      } catch (error) {
+        decl.warn(result, error.message, {
+          word: decl.value,
+          index: decl.index,
+        })
+      }
     })
   }
 })

--- a/test/fixtures/color-custom-properties.css
+++ b/test/fixtures/color-custom-properties.css
@@ -1,0 +1,8 @@
+body {
+  color: rgb(255, 0, 0);
+  color: color(var(--red));
+  color: color(rgb(255, 0, 0) tint(50%));
+  color: color(var(--red) tint(50%));
+  color: color(rgb(255, 0, 0) tint(var(--tintPercent)));
+  color: color(var(--red) tint(var(--tintPercent)));
+}

--- a/test/fixtures/color-custom-properties.expected.css
+++ b/test/fixtures/color-custom-properties.expected.css
@@ -1,0 +1,8 @@
+body {
+  color: rgb(255, 0, 0);
+  color: color(var(--red));
+  color: rgb(255, 128, 128);
+  color: color(var(--red) tint(50%));
+  color: color(rgb(255, 0, 0) tint(var(--tintPercent)));
+  color: color(var(--red) tint(var(--tintPercent)));
+}

--- a/test/index.js
+++ b/test/index.js
@@ -23,12 +23,82 @@ test("color()", function(t) {
   t.end()
 })
 
-test("throw errors", function(t) {
-  t.throws(function() {
-    return postcss(plugin()).process(read(filename("fixtures/error"))).css
-  },
-  /Unable to parse color from string/,
-  "throws a readable error when a color can't be parsed")
-
+test("color(var(--customProperty))", function(t) {
+  compareFixtures(t, "color-custom-properties", "should preserve color() with custom properties");
   t.end()
+})
+
+test("logs message when color() contains var(--customProperty)", function(t) {
+  postcss(plugin()).process(read(filename("fixtures/color-custom-properties")))
+    .then(function(result) {
+      const expectedWords = [
+        "color(var(--red))",
+        "color(var(--red) tint(50%))",
+        "color(rgb(255, 0, 0) tint(var(--tintPercent)))",
+        "color(var(--red) tint(var(--tintPercent)))"
+      ]
+
+      t.equal(
+        result.messages.length,
+        expectedWords.length,
+        "expected a message every time a color function is skipped"
+      )
+
+      result.messages.forEach(function(message, i) {
+        t.equal(
+          message.type,
+          "skipped-color-function-with-custom-property",
+          "expected `message.type` to indicate reason for message"
+        )
+
+        t.equal(
+          message.plugin,
+          "postcss-color-function",
+          "expected `message.plugin` to match this plugin's name"
+        )
+
+        t.equal(
+          message.word,
+          expectedWords[i],
+          "expected `message.word` to contain declaration value"
+        )
+
+        t.equal(
+          message.message,
+          "Skipped color function with custom property `" + expectedWords[i] + "`",
+          "expected `message.message` to contain reason for message"
+        )
+      })
+
+      t.end()
+    })
+})
+
+test("logs warning when color() value cannot be parsed", function(t) {
+  postcss(plugin()).process(read(filename("fixtures/error")))
+    .then(function(result) {
+      var warnings = result.warnings();
+      t.equals(warnings.length, 1, "expected only 1 warning");
+
+      var warning = warnings[0]
+      t.equals(
+        warning.plugin,
+        "postcss-color-function",
+        "expected `warning.plugin` to match this plugin's name"
+      )
+
+      t.equals(
+        warning.word,
+        "color(blurp a(+10%))",
+        "expected `warning.word` to match color() declaration"
+      )
+
+      t.equals(
+        warning.text,
+        "<css input>:2:3: Unable to parse color from string \"blurp\"",
+        "expected `warning.text` to contain a readable error when a color can't be parsed"
+      )
+
+      t.end()
+    })
 })


### PR DESCRIPTION
Fixes #4 by skipping any `color` functions that contain a `var`