### PR TITLE
Add postcss warning when color function cannot be parsed

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,15 +10,22 @@ var helpers = require("postcss-message-helpers")
  * PostCSS plugin to transform color()
  */
 module.exports = postcss.plugin("postcss-color-function", function() {
-  return function(style) {
+  return function(style, result) {
     style.walkDecls(function transformDecl(decl) {
       if (!decl.value || decl.value.indexOf("color(") === -1) {
         return
       }
 
-      decl.value = helpers.try(function transformColorValue() {
-        return transformColor(decl.value)
-      }, decl.source)
+      try {
+        decl.value = helpers.try(function transformColorValue() {
+          return transformColor(decl.value)
+        }, decl.source)
+      } catch (error) {
+        decl.warn(result, error.message, {
+          word: decl.value,
+          index: decl.index,
+        })
+      }
     })
   }
 })

--- a/test/index.js
+++ b/test/index.js
@@ -23,12 +23,31 @@ test("color()", function(t) {
   t.end()
 })
 
-test("throw errors", function(t) {
-  t.throws(function() {
-    return postcss(plugin()).process(read(filename("fixtures/error"))).css
-  },
-  /Unable to parse color from string/,
-  "throws a readable error when a color can't be parsed")
+test("logs warning when color() value cannot be parsed", function(t) {
+  postcss(plugin()).process(read(filename("fixtures/error")))
+    .then(function(result) {
+      var warnings = result.warnings();
+      t.equals(warnings.length, 1, "expected only 1 warning");
 
-  t.end()
+      var warning = warnings[0]
+      t.equals(
+        warning.plugin,
+        "postcss-color-function",
+        "expected `warning.plugin` to match this plugin's name"
+      )
+
+      t.equals(
+        warning.word,
+        "color(blurp a(+10%))",
+        "expected `warning.word` to match color() declaration"
+      )
+
+      t.equals(
+        warning.text,
+        "<css input>:2:3: Unable to parse color from string \"blurp\"",
+        "expected `warning.text` to contain a readable error when a color can't be parsed"
+      )
+
+      t.end()
+    })
 })


### PR DESCRIPTION
When processing an invalid value `css-color-function` will throw errors.
This change catches those errors and turns them into postcss warnings.