### PR TITLE
Add CSS Standard Status

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# postcss-color-function [![Build Status](https://travis-ci.org/postcss/postcss-color-function.svg)](https://travis-ci.org/postcss/postcss-color-function)
+# postcss-color-function [![CSS Standard Status](https://jonathantneal.github.io/css-db/badge/css-color-modifying-colors.svg)](https://jonathantneal.github.io/css-db/#css-color-modifying-colors) [![Build Status](https://travis-ci.org/postcss/postcss-color-function.svg)](https://travis-ci.org/postcss/postcss-color-function)
 
 > [PostCSS](https://github.com/postcss/postcss) plugin to transform [W3C CSS color function][specs] to more compatible CSS.
 


### PR DESCRIPTION
Hey there. I’m just trying to get the word out that cssdb has badges to help users know the status of your CSS polyfill.

[cssdb](https://jonathantneal.github.io/css-db/) is a list I’m compiling of CSS features and their positions in the process of becoming implemented web standards.