### PR TITLE
upgrade color-string dependency to take care of vulnerability #61

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   ],
   "dependencies": {
     "css-color-function": "~1.3.3",
-    "postcss": "^6.0.23",
+    "postcss": "^8.3.8",
     "postcss-message-helpers": "^2.0.0",
     "postcss-value-parser": "^3.3.1"
   },


### PR DESCRIPTION
More on vulnerability https://nvd.nist.gov/vuln/detail/CVE-2021-29060

